### PR TITLE
Rawlings changes

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -82,10 +82,24 @@ export PATH="$PATH:$HOME/.composer/vendor/bin"
 alias dcwp='docker-compose run --rm cli wp'
 
 # Node Version Check
+# https://medium.com/@alberto.schiabel/npm-tricks-part-1-get-list-of-globally-installed-packages-39a240347ef0
 npm() {
   if [[ $@ == "whichversion" ]]; then
     command find . -name package.json | xargs grep -h node\": | sort | uniq -c
+  elif [[ $@ == 'global' ]]; then
+    command npm list -g --depth 0
   else
     command npm "$@"
   fi
 }
+
+clean() {
+  for branch in $(git branch -r --merged master | grep origin | grep -v develop | grep -v master)
+  do
+    sleep 2
+    git push origin --delete "${branch#*/}"
+  done
+}
+
+# Hide the “default interactive shell is now zsh” warning on macOS.
+export BASH_SILENCE_DEPRECATION_WARNING=1;

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,2 +1,17 @@
 *.DS_Store
-.atomignore
+*.code-workspace
+
+#https://github.com/github/gitignore/blob/master/Global/MicrosoftOffice.gitignore
+*.tmp
+
+# Word temporary
+~$*.doc*
+
+# Word Auto Backup File
+Backup of *.doc*
+
+# Excel temporary
+~$*.xls*
+
+# Excel Backup File
+*.xlk

--- a/Code/settings.json
+++ b/Code/settings.json
@@ -5,8 +5,6 @@
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true,
     "editor.fontSize": 16,
-    "editor.formatOnPaste": true,
-    "editor.insertSpaces": false,
     "editor.minimap.enabled": false,
     "editor.multiCursorModifier": "ctrlCmd",
     "editor.renderWhitespace": "all",
@@ -17,7 +15,7 @@
     "editor.wordWrap": "on",
     "extensions.ignoreRecommendations": false,
     "files.exclude": {
-        "**/.git": false
+      "**/.git": false
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
@@ -33,9 +31,49 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
+        // "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": false,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "[isml]": {
+        "editor.formatOnSave": false,
+        // "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "editor.tabSize": 2,
     "emmet.showAbbreviationSuggestions": false,
-    "emmet.showExpandedAbbreviation": "never"
+    "emmet.showExpandedAbbreviation": "never",
+    "prettier.disableLanguages": [
+        "vue",
+        "js",
+        "isml"
+    ],
+    "editor.formatOnSave": false,
+    "editor.detectIndentation": false,
+    "[jsonc]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[html]": {
+      "editor.defaultFormatter": "vscode.html-language-features"
+    },
+    "extension.prophet.cartridges.path": "int_square_loyalty:app_rawlings:app_lyonscg:bm_listrak:int_listrak_pipelines:int_cybersource:int_dis:int_lcg_vertex:int_QAS:int_deckcommerce:int_pixlee:int_bazaarvoice:int_profitpoint:bc_integrationframework:int_tealium:app_cc:int_googleFeed:bc_orderguard:app_pagedesigner_sg:app_storefront_controllers:app_storefront_pipelines:app_storefront_core:module_pagedesigner",
+    "extension.prophet.upload.enabled": true,
+    "extension.prophet.clean.on.start": false,
+    "workbench.editor.closeEmptyGroups": false,
+    "explorer.compactFolders": false,
+    "explorer.autoReveal": false,
+    "extension.prophet.ignore.list": [
+      "node_modules",
+      "\\.git",
+      "\\.zip$",
+      "\\.vscode"
+    ],
+    "grammarly.userWords": [
+      "sfra",
+      "webpack"
+    ],
+    "git.autofetch": true,
+    "javascript.preferences.quoteStyle": "single",
+    "prettier.singleQuote": true,
+    "editor.accessibilitySupport": "off",
+    "javascript.format.enable": false
 }


### PR DESCRIPTION
Leaving this comment here incase future me goes digging for some reason.

I don't entirely remember why I added all of these things while @ Rawlings..
- I added a helper thing to get all the globally installed nodejs packages.  I think this was because I wanted to know if Gulp was installed globally or not.  Handy w/ NVM when bouncing between environments.
- I added the clean method to nuke a few hundred merged branches quickly.  This might be too narrow to be something I keep in here and it'll get relegated into a gist or something
- Updated the global gitignore so I wouldn't accidentally commit all the temp files that Office generates while I was working through cartridge documentation
- Random preference changes.  I see a lot of SFCC specific cruft that I'll need to clean out. :(